### PR TITLE
Bug in both template files

### DIFF
--- a/tmpl/default.php
+++ b/tmpl/default.php
@@ -7,7 +7,7 @@
  */
 defined('_JEXEC') or die;
 
-if ($loadCSS = 1)
+if ($loadCSS == 1)
 {
 	$document = JFactory::getDocument();
 	// add minified CSS stylesheet (original CSS: db8socialmediashare_style.css)

--- a/tmpl/fontawesome.php
+++ b/tmpl/fontawesome.php
@@ -7,7 +7,7 @@
  */
 defined('_JEXEC') or die;
 
-if ($loadCSS = 1)
+if ($loadCSS == 1)
 {
 	$document = JFactory::getDocument();
 	// add minified Font Awesome CSS stylesheet from CDN


### PR DESCRIPTION
Both template files (default.php and fontawesome.php) have the same bug. The if stament testing whether the CSS should be loaded has a single '=', effectively assigning 1 to $loadCSS instead of testing if $loadCSS equals 1. I added an additonal '=' to the if statement in both files.